### PR TITLE
[Update] admin orders

### DIFF
--- a/app/controllers/admin/order_items_controller.rb
+++ b/app/controllers/admin/order_items_controller.rb
@@ -8,12 +8,12 @@ class Admin::OrderItemsController < ApplicationController
   order = Order.find(@order_item.order_id)
 
     if @order_item.update(order_item_params)
-      if @order_item.status == "製作中"
-        order.status = "製作中"
+      if @order_item.status == OrderItem.statuses.key(2)
+        order.status = Order.statuses.key(2)
         order.save
-      elsif @order_item.status == "製作完了"
-        if OrderItem.where(order_id: order.id).count == OrderItem.where(order_id: order.id, status: "製作完了" ).count
-           order.status = "発送準備中"
+      elsif @order_item.status == OrderItem.statuses.key(3)
+        if OrderItem.where(order_id: order.id).count == OrderItem.where(order_id: order.id, status: 3 ).count
+           order.status = Order.statuses.key(3)
            order.save
         end
       end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -14,11 +14,10 @@ class Admin::OrdersController < ApplicationController
     @order = Order.find(params[:id])
     @order.update(order_params)
     @order_items = @order.order_items
-
-    if @order.status == "入金確認"
-      @order_items.each do |order_items|
-        order_items.status = "製作待ち"
-        order_items.save
+    if @order.status == Order.statuses.key(1)
+      @order_items.each do |order_item|
+        order_item.status = 1
+        order_item.save
       end
     end
     flash[:success] = "製作ステータスを変更しました。"

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -33,8 +33,7 @@ class Public::OrdersController < ApplicationController
     else
       render 'new'
     end
-
-    cart_items = current_customer.cart_items
+    
     @cart_items = CartItem.where(customer_id: current_customer.id)
     @shipping_fee = 800
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,7 +7,7 @@ class Order < ApplicationRecord
     
     belongs_to :customer
     enum payment_method: { credit_card: 0, transfer: 1 }
-    enum status: { "入金待ち":0, "入金確認":1, "製作中":2, "発送準備中":3, "発送済":4 }
-# 　　enum status: { waiting_payment:0, confirmation_payment: 1, under_process: 2, waiting_shipping: 3, completed_shipping: 4 }
+    # enum status: { "入金待ち":0, "入金確認":1, "製作中":2, "発送準備中":3, "発送済":4 }
+    enum status: { waiting_payment: 0, confirmation_payment: 1, under_process: 2, waiting_shipping: 3, completed_shipping: 4 }
 
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -2,7 +2,8 @@ class OrderItem < ApplicationRecord
     belongs_to :item
     belongs_to :order
     
-    enum status: { 着手不可:0, 製作待ち: 1, 製作中: 2, 製作完了: 3 }
+    # enum status: { 着手不可:0, 製作待ち: 1, 製作中: 2, 製作完了: 3 }
+    enum status: { waiting: 0, waiting_process: 1, under_process: 2, completed_process: 3 }
     
       # 消費税
   def with_tax_price

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -16,7 +16,7 @@
             <% @orders.each do |order| %>
               <tr>
                 <td><u><%= link_to order.created_at.strftime("%Y/%m/%d %H:%M:%S"), admin_order_path(order), class: "text-reset " %></u></td>
-                <td><%= order.name %></td>
+                <td><%= order.customer.last_name + order.customer.first_name%></td>
                 <td>
                   <%= OrderItem.where(order_id: order.id).pluck(:amount).sum %>
                 </td>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -15,7 +15,9 @@
         </tr>
         <tr>
           <th>配送先</th>
-          <th>〒<%= @selected_order.postcode%><%= @selected_order.address%><%= @selected_order.name%></th>
+          <th>〒<%= @selected_order.postcode%> <%= @selected_order.address%><br>
+              <%= @selected_order.name%>
+          </th>
         </tr>
         <tr>
           <th>支払方法</th>
@@ -24,7 +26,9 @@
         <tr>
           <th>注文ステータス</th>
           <td>
-            <%= f.select :status, {"入金待ち" => Order.statuses.key(0), "入金確認" => Order.statuses.key(1), "製作中" => Order.statuses.key(2), "発送準備中" => Order.statuses.key(3), "発送済" => Order.statuses.key(4)}, class: "status" %>
+            <!-- "入金待ち":0, "入金確認":1, "製作中":2, "発送準備中":3, "発送済":4 -->
+            <%= f.select :status, {Order.statuses_i18n[Order.statuses.key(0)]=> Order.statuses.key(0), Order.statuses_i18n[Order.statuses.key(1)] => Order.statuses.key(1), 
+            Order.statuses_i18n[Order.statuses.key(2)] => Order.statuses.key(2), Order.statuses_i18n[Order.statuses.key(3)] => Order.statuses.key(3), Order.statuses_i18n[Order.statuses.key(4)]=> Order.statuses.key(4)}, class: "status" %>
             <%= f.submit "更新", class: 'btn btn-success' %>
             
           </td>
@@ -51,7 +55,9 @@
           
           <td>
             <%= form_with model: selected_order_item, url: admin_order_item_path(selected_order_item), method: :patch, local: true do |f| %>
-            <%= f.select :status, {"着手不可" => OrderItem.statuses.key(0), "製作待ち" => OrderItem.statuses.key(1),"製作中" => OrderItem.statuses.key(2), "製作完了" => OrderItem.statuses.key(3)}, class: "status" %>
+            <!-- # enum status: { 着手不可:0, 製作待ち: 1, 製作中: 2, 製作完了: 3 }-->
+            <%= f.select :status, {OrderItem.statuses_i18n[OrderItem.statuses.key(0)] => OrderItem.statuses.key(0), OrderItem.statuses_i18n[OrderItem.statuses.key(1)]=> OrderItem.statuses.key(1),
+            OrderItem.statuses_i18n[OrderItem.statuses.key(2)]=> OrderItem.statuses.key(2), OrderItem.statuses_i18n[OrderItem.statuses.key(3)]=> OrderItem.statuses.key(3)}, class: "status" %>
             <%= f.submit  "更新", class: 'btn btn-success' %>
             <% end %>
           </td>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -7,7 +7,7 @@
       <table>
         <tr>
           <th>購入者</th>
-          <th><%= @customer.last_name + @customer.first_name %></th>
+          <th><u><%= link_to @customer.last_name + @customer.first_name, admin_customer_path(@customer), class: "text-reset" %></u></th>
         </tr>
         <tr>
           <th>注文日</th>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -24,8 +24,7 @@
         <tr>
           <th>注文ステータス</th>
           <td>
-            
-            <%= f.select :status, ["入金待ち", "入金確認","製作中","発送準備中","発送済"], class: "status" %>
+            <%= f.select :status, {"入金待ち" => Order.statuses.key(0), "入金確認" => Order.statuses.key(1), "製作中" => Order.statuses.key(2), "発送準備中" => Order.statuses.key(3), "発送済" => Order.statuses.key(4)}, class: "status" %>
             <%= f.submit "更新", class: 'btn btn-success' %>
             
           </td>
@@ -52,7 +51,7 @@
           
           <td>
             <%= form_with model: selected_order_item, url: admin_order_item_path(selected_order_item), method: :patch, local: true do |f| %>
-            <%= f.select :status, ["着手不可", "製作待ち","製作中","製作完了"], class: "status" %>
+            <%= f.select :status, {"着手不可" => OrderItem.statuses.key(0), "製作待ち" => OrderItem.statuses.key(1),"製作中" => OrderItem.statuses.key(2), "製作完了" => OrderItem.statuses.key(3)}, class: "status" %>
             <%= f.submit  "更新", class: 'btn btn-success' %>
             <% end %>
           </td>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -22,7 +22,7 @@
             <%= f.radio_button :address_option, 1, class: "form-check-input" %>
             <%= f.label :address_option, value: 1, class: "form-check-label" do %>
                 <h6>登録済住所から選択</h6>
-                <%= f.select :address_id, options_from_collection_for_select(Address.all, :id, :address_display) %>
+                <%= f.select :address_id, options_from_collection_for_select(Address.where(customer_id: current_customer.id), :id, :address_display) %>
             <% end%>
             <br>
             <%= f.radio_button :address_option, 2, class: "form-check-input" %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,7 +6,7 @@ ja:
                 transfer: "銀行振込"
             status:
                 waiting_payment: "入金待ち"
-                cofirmation_payment: "入金確認中"
+                confirmation_payment: "入金確認中"
                 under_process: "製作中"
                 waiting_shipping: "発送準備中"
                 completed_shipping: "発送済み"


### PR DESCRIPTION
# admin/orders修正
- じゅんじゅん指摘箇所の修正（注文履歴の購入者、注文履歴詳細の購入者リンク、登録配送先）
- enumの設定が日本語:数字だったものを英語:数字に変更しました