### PR TITLE
[Update]Layout orders show/orders complete

### DIFF
--- a/app/controllers/admin/order_items_controller.rb
+++ b/app/controllers/admin/order_items_controller.rb
@@ -3,26 +3,33 @@ class Admin::OrderItemsController < ApplicationController
  before_action :authenticate_admin!
 
  def update
-
   @order_item = OrderItem.find(params[:id])
   order = Order.find(@order_item.order_id)
 
     if @order_item.update(order_item_params)
       if @order_item.status == OrderItem.statuses.key(2)
         order.status = Order.statuses.key(2)
+        flash[:success] = []
+        flash[:success] << "注文ステータスを変更しました。"
         order.save
       elsif @order_item.status == OrderItem.statuses.key(3)
         if OrderItem.where(order_id: order.id).count == OrderItem.where(order_id: order.id, status: 3 ).count
            order.status = Order.statuses.key(3)
+           flash[:success] = []
+           flash[:success] << "注文ステータスを変更しました。"
            order.save
         end
       end
-    flash[:success] = "製作ステータスを変更しました。"
+    if flash[:success].nil?
+      flash[:success] = "製作ステータスを変更しました。"
+    else
+      flash[:success] << "製作ステータスを変更しました。"
+    end
     redirect_to admin_order_path(order)
     else
       redirect_back(fallback_location: root_path)
     end
-end
+ end
 
  private
  def order_item_params

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -11,6 +11,7 @@ class Admin::OrdersController < ApplicationController
   end
 
   def update
+    # enum status: { 着手不可:0, 製作待ち: 1, 製作中: 2, 製作完了: 3 }
     @order = Order.find(params[:id])
     @order.update(order_params)
     @order_items = @order.order_items
@@ -18,9 +19,17 @@ class Admin::OrdersController < ApplicationController
       @order_items.each do |order_item|
         order_item.status = 1
         order_item.save
+        # 複数メッセージ表示のための配列準備
+        flash[:success] = []
+        flash[:success] << "製作ステータスを変更しました。"
       end
     end
-    flash[:success] = "製作ステータスを変更しました。"
+    # 複数メッセージ表示のための場合分け
+    if flash[:success].nil?
+      flash[:success] = "注文ステータスを変更しました。"
+    else
+      flash[:success] << "注文ステータスを変更しました。"
+    end
     redirect_to admin_order_path
   end
 

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -16,7 +16,7 @@ class Public::OrdersController < ApplicationController
     if params[:order][:address_option] == "0"
       @order.postcode = current_customer.postcode
       @order.address = current_customer.address
-      @order.name = current_customer.first_name + current_customer.last_name
+      @order.name = current_customer.last_name + current_customer.first_name
       
     elsif params[:order][:address_option] == "1"
       @addresses = Address.all
@@ -29,7 +29,6 @@ class Public::OrdersController < ApplicationController
       @order.postcode = params[:order][:postcode]
       @order.address = params[:order][:address]
       @order.name = params[:order][:name]
-      
     else
       render 'new'
     end

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -6,11 +6,11 @@
   <div class="row">
       <div class="col-sm-12 col-md-11 col-lg-10 col-xl-10 px-sm-0 px-md-1 mx-auto">
         <table class="table">
-          <thead class="thead-light">
-            <th>購入日時</th>
-            <th>購入者</th>
-            <th>注文個数</th>
-            <th>注文ステータス</th>
+          <thead>
+            <th class="bg-light">購入日時</th>
+            <th class="bg-light">購入者</th>
+            <th class="bg-light">注文個数</th>
+            <th class="bg-light">注文ステータス</th>
           </thead>
           <tbody>
             <% @orders.each do |order| %>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -29,7 +29,7 @@
         <td>
           <!-- "入金待ち":0, "入金確認":1, "製作中":2, "発送準備中":3, "発送済":4 -->
           <%= f.select :status, {Order.statuses_i18n[Order.statuses.key(0)] => Order.statuses.key(0), Order.statuses_i18n[Order.statuses.key(1)] => Order.statuses.key(1), 
-          Order.statuses_i18n[Order.statuses.key(2)] => Order.statuses.key(2), Order.statuses_i18n[Order.statuses.key(3)] => Order.statuses.key(3), Order.statuses_i18n[Order.statuses.key(4)]=> Order.statuses.key(4)}, {},class: "form-control" %>
+          Order.statuses_i18n[Order.statuses.key(2)] => Order.statuses.key(2), Order.statuses_i18n[Order.statuses.key(3)] => Order.statuses.key(3), Order.statuses_i18n[Order.statuses.key(4)]=> Order.statuses.key(4)}, {},class: "form-control-sm" %>
           <%= f.submit "更新", class: 'btn btn-sm btn-success' %>
         </td>
       </tr>
@@ -41,12 +41,12 @@
       <!--左側-->
       <div class="col-md-8">
         <table class="table">
-          <thead class="thead-light">
-            <th>商品名</th>
-            <th>単価（税込）</th>
-            <th>数量</th>
-            <th>小計</th>
-            <th>製作ステータス</th>
+          <thead>
+            <th class="bg-light">商品名</th>
+            <th class="bg-light">単価（税込）</th>
+            <th class="bg-light">数量</th>
+            <th class="bg-light">小計</th>
+            <th class="bg-light">製作ステータス</th>
           </thead>
           
           <tbody>
@@ -61,7 +61,7 @@
                 <%= form_with model: selected_order_item, url: admin_order_item_path(selected_order_item), method: :patch, local: true do |f| %>
                 <!-- # enum status: { 着手不可:0, 製作待ち: 1, 製作中: 2, 製作完了: 3 }-->
                 <%= f.select :status, {OrderItem.statuses_i18n[OrderItem.statuses.key(0)] => OrderItem.statuses.key(0), OrderItem.statuses_i18n[OrderItem.statuses.key(1)]=> OrderItem.statuses.key(1),
-                OrderItem.statuses_i18n[OrderItem.statuses.key(2)]=> OrderItem.statuses.key(2), OrderItem.statuses_i18n[OrderItem.statuses.key(3)]=> OrderItem.statuses.key(3)}, class: 'form-control' %>
+                OrderItem.statuses_i18n[OrderItem.statuses.key(2)]=> OrderItem.statuses.key(2), OrderItem.statuses_i18n[OrderItem.statuses.key(3)]=> OrderItem.statuses.key(3)}, {}, class: 'form-control-sm' %>
                 <%= f.submit  "更新", class: 'btn btn-sm btn-success' %>
                 <% end %>
               </td>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,99 +1,93 @@
-<div class="container">
-  <div class="row">
-    <div class="mx-auto">
-
-      <h3>注文履歴詳細</h3>
-      <%= form_with model: @selected_order, url: admin_order_path, local: true do |f| %>
-      <table>
-        <tr>
-          <th>購入者</th>
-          <th><u><%= link_to @customer.last_name + @customer.first_name, admin_customer_path(@customer), class: "text-reset" %></u></th>
-        </tr>
-        <tr>
-          <th>注文日</th>
-          <th><%= @selected_order.created_at.strftime("%Y/%m/%d") %></th>
-        </tr>
-        <tr>
-          <th>配送先</th>
-          <th>〒<%= @selected_order.postcode%> <%= @selected_order.address%><br>
-              <%= @selected_order.name%>
-          </th>
-        </tr>
-        <tr>
-          <th>支払方法</th>
-          <th><%= Order.payment_methods_i18n[@selected_order.payment_method] %></th>
-        </tr>
-        <tr>
-          <th>注文ステータス</th>
-          <td>
-            <!-- "入金待ち":0, "入金確認":1, "製作中":2, "発送準備中":3, "発送済":4 -->
-            <%= f.select :status, {Order.statuses_i18n[Order.statuses.key(0)] => Order.statuses.key(0), Order.statuses_i18n[Order.statuses.key(1)] => Order.statuses.key(1), 
-            Order.statuses_i18n[Order.statuses.key(2)] => Order.statuses.key(2), Order.statuses_i18n[Order.statuses.key(3)] => Order.statuses.key(3), Order.statuses_i18n[Order.statuses.key(4)]=> Order.statuses.key(4)}, class: "status" %>
-            <%= f.submit "更新", class: 'btn btn-success' %>
-            
-          </td>
-        </tr>
-      </table>
-      <% end %>
-
-      <table class="table">
-        <header>
-          <th>商品名</th>
-          <th>単価（税込）</th>
-          <th>数量</th>
-          <th>小計</th>
-          <th>製作ステータス</th>
-        </header>
-        
-        
-        <% @selected_order.order_items.each do |selected_order_item| %>
-        <tr>
-          <td><%= selected_order_item.item.name %></td>
-          <td><%= number_with_delimiter((selected_order_item.item.with_tax_price).to_i) %></td>
-          <td><%= selected_order_item.amount %></td>
-          <td><%= number_with_delimiter(selected_order_item.item.price) %></td>
+<div class="container  my-4 px-sm-0">
+  <div class="px-1 ml-md-2">
+    <h5 class="bg-light text-center ml-5 mb-4" style="width: 150px;">注文履歴詳細</h5> 
+  </div>
+  <!--上段-->
+  <div class="row"> 
+    <%= form_with model: @selected_order, url: admin_order_path, local: true do |f| %>
+    <table class="table table-borderless">
+      <tr>
+        <th>購入者</th>
+        <td><u><%= link_to @customer.last_name + @customer.first_name, admin_customer_path(@customer), class: "text-reset" %></u></td>
+      </tr>
+      <tr>
+        <th>注文日</th>
+        <td><%= @selected_order.created_at.strftime("%Y/%m/%d") %></td>
+      </tr>
+      <tr>
+        <th>配送先</th>
+        <td>〒<%= @selected_order.postcode%> <%= @selected_order.address%><br>
+            <%= @selected_order.name%>
+        </td>
+      </tr>
+      <tr>
+        <th>支払方法</th>
+        <td><%= Order.payment_methods_i18n[@selected_order.payment_method] %></td>
+      </tr>
+      <tr>
+        <th>注文ステータス</th>
+        <td>
+          <!-- "入金待ち":0, "入金確認":1, "製作中":2, "発送準備中":3, "発送済":4 -->
+          <%= f.select :status, {Order.statuses_i18n[Order.statuses.key(0)] => Order.statuses.key(0), Order.statuses_i18n[Order.statuses.key(1)] => Order.statuses.key(1), 
+          Order.statuses_i18n[Order.statuses.key(2)] => Order.statuses.key(2), Order.statuses_i18n[Order.statuses.key(3)] => Order.statuses.key(3), Order.statuses_i18n[Order.statuses.key(4)]=> Order.statuses.key(4)}, class: "form-control" %>
+          <%= f.submit "更新", class: 'btn btn-sm btn-success' %>
+        </td>
+      </tr>
+    </table>
+    <% end %>
+  </div>
+    <!--下段-->
+    <div class="row">
+      <!--左側-->
+      <div class="col-md-8">
+        <table class="table">
+          <thead class="thead-light">
+            <th>商品名</th>
+            <th>単価（税込）</th>
+            <th>数量</th>
+            <th>小計</th>
+            <th>製作ステータス</th>
+          </thead>
           
-          <td>
-            <%= form_with model: selected_order_item, url: admin_order_item_path(selected_order_item), method: :patch, local: true do |f| %>
-            <!-- # enum status: { 着手不可:0, 製作待ち: 1, 製作中: 2, 製作完了: 3 }-->
-            <%= f.select :status, {OrderItem.statuses_i18n[OrderItem.statuses.key(0)] => OrderItem.statuses.key(0), OrderItem.statuses_i18n[OrderItem.statuses.key(1)]=> OrderItem.statuses.key(1),
-            OrderItem.statuses_i18n[OrderItem.statuses.key(2)]=> OrderItem.statuses.key(2), OrderItem.statuses_i18n[OrderItem.statuses.key(3)]=> OrderItem.statuses.key(3)}, class: "status" %>
-            <%= f.submit  "更新", class: 'btn btn-success' %>
+          <tbody>
+            <% @selected_order.order_items.each do |selected_order_item| %>
+            <tr>
+              <td><%= selected_order_item.item.name %></td>
+              <td><%= number_with_delimiter((selected_order_item.item.with_tax_price).to_i) %></td>
+              <td><%= selected_order_item.amount %></td>
+              <td><%= number_with_delimiter(selected_order_item.item.price) %></td>
+              
+              <td>
+                <%= form_with model: selected_order_item, url: admin_order_item_path(selected_order_item), method: :patch, local: true do |f| %>
+                <!-- # enum status: { 着手不可:0, 製作待ち: 1, 製作中: 2, 製作完了: 3 }-->
+                <%= f.select :status, {OrderItem.statuses_i18n[OrderItem.statuses.key(0)] => OrderItem.statuses.key(0), OrderItem.statuses_i18n[OrderItem.statuses.key(1)]=> OrderItem.statuses.key(1),
+                OrderItem.statuses_i18n[OrderItem.statuses.key(2)]=> OrderItem.statuses.key(2), OrderItem.statuses_i18n[OrderItem.statuses.key(3)]=> OrderItem.statuses.key(3)}, class: 'form-control' %>
+                <%= f.submit  "更新", class: 'btn btn-sm btn-success' %>
+                <% end %>
+              </td>
+             </tr>
             <% end %>
-          </td>
-            
-          
-        
-         </tr>
-         
-        <% end %>
-      </table>
-
-  </div>
-    <div class="col-xs-4">
-      <div>
-        <p>
-          <strong class="col-xs-3">商品合計</strong>
-          ¥<%= (@selected_order.payment - @selected_order.shipping_fee).to_s(:delimited)%>
-        </p>
+          </tbody>
+        </table>
       </div>
-      <br>
-  
-      <div>
-        <p>
-          <strong class="col-xs-2">送料</strong>
-          ¥<%= @selected_order.shipping_fee.to_s(:delimited)%>
-        </p>
+      <!--右側-->
+      <div class="col-md-4 align-self-end">
+        <table class="table table-borderless">
+          <tr>
+              <th>商品合計</th>
+              <td><%= (@selected_order.payment - @selected_order.shipping_fee).to_s(:delimited)%> 円</td>
+          </tr>
+          <tr>
+            <p>
+              <th class="col-xs-2">送料</th>
+              <td><%= @selected_order.shipping_fee.to_s(:delimited)%> 円</td>
+            </p>
+          </tr>
+          <tr>
+              <th class="col-xs-4">請求金額合計</th>
+              <td><b><%= @selected_order.payment.to_s(:delimited) %> 円</b></td>
+          </tr>
+        </table>
       </div>
-      <br>
-  
-      <div>
-        <p>
-          <strong class="col-xs-4">請求金額合計</strong>
-          ¥<%= @selected_order.payment.to_s(:delimited) %>
-        </p>
-      </div>
-      <br>
     </div>
-  </div>
 </div>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -29,7 +29,7 @@
         <td>
           <!-- "入金待ち":0, "入金確認":1, "製作中":2, "発送準備中":3, "発送済":4 -->
           <%= f.select :status, {Order.statuses_i18n[Order.statuses.key(0)] => Order.statuses.key(0), Order.statuses_i18n[Order.statuses.key(1)] => Order.statuses.key(1), 
-          Order.statuses_i18n[Order.statuses.key(2)] => Order.statuses.key(2), Order.statuses_i18n[Order.statuses.key(3)] => Order.statuses.key(3), Order.statuses_i18n[Order.statuses.key(4)]=> Order.statuses.key(4)}, class: "form-control" %>
+          Order.statuses_i18n[Order.statuses.key(2)] => Order.statuses.key(2), Order.statuses_i18n[Order.statuses.key(3)] => Order.statuses.key(3), Order.statuses_i18n[Order.statuses.key(4)]=> Order.statuses.key(4)}, {},class: "form-control" %>
           <%= f.submit "更新", class: 'btn btn-sm btn-success' %>
         </td>
       </tr>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -27,7 +27,7 @@
           <th>注文ステータス</th>
           <td>
             <!-- "入金待ち":0, "入金確認":1, "製作中":2, "発送準備中":3, "発送済":4 -->
-            <%= f.select :status, {Order.statuses_i18n[Order.statuses.key(0)]=> Order.statuses.key(0), Order.statuses_i18n[Order.statuses.key(1)] => Order.statuses.key(1), 
+            <%= f.select :status, {Order.statuses_i18n[Order.statuses.key(0)] => Order.statuses.key(0), Order.statuses_i18n[Order.statuses.key(1)] => Order.statuses.key(1), 
             Order.statuses_i18n[Order.statuses.key(2)] => Order.statuses.key(2), Order.statuses_i18n[Order.statuses.key(3)] => Order.statuses.key(3), Order.statuses_i18n[Order.statuses.key(4)]=> Order.statuses.key(4)}, class: "status" %>
             <%= f.submit "更新", class: 'btn btn-success' %>
             

--- a/app/views/layouts/_flash_message.html.erb
+++ b/app/views/layouts/_flash_message.html.erb
@@ -1,6 +1,12 @@
-<% flash.each do |key, value| %>
-  <div class="alert alert-<%= bootstrap_alert(key) %> alert-dismissible fade show">
-    <span><%= value %></span>
+<% flash.each do |message| %>
+  <div class="alert alert-<%= bootstrap_alert(message[0]) %> alert-dismissible fade show">
+    <% if message[1].is_a?(Array) %>
+      <% message[1].each do |value| %>
+        <span><%= value %><br></span>
+      <% end %>
+    <% else %>
+      <span><%= message[1] %></span>
+    <% end %>
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/app/views/public/orders/complete.html.erb
+++ b/app/views/public/orders/complete.html.erb
@@ -1,6 +1,6 @@
-<div class="container">
+<div class="container h-50">
   <div class="row mx-auto text-center">
-    <div class="col-12">
+    <div class="h-50 col-12">
       <h5>ご注文ありがとうございました！</h5>
     </div>
   </div>

--- a/app/views/public/orders/complete.html.erb
+++ b/app/views/public/orders/complete.html.erb
@@ -1,7 +1,5 @@
-<div class="container h-50">
-  <div class="row mx-auto text-center">
-    <div class="h-50 col-12">
-      <h5>ご注文ありがとうございました！</h5>
-    </div>
+<div class="container my-5 px-sm-1 d-flex align-items-center justify-content-center" style="height: 70vh">
+  <div class="text-center vertical-center">
+      <h3>ご注文ありがとうございました！</h3>
   </div>
 </div>

--- a/app/views/public/orders/index.html.erb
+++ b/app/views/public/orders/index.html.erb
@@ -6,14 +6,14 @@
   <div class="row">
     <div class="col-12">
       <table class="table table-bordered">
-        <thead class="thead-light">
+        <thead>
           <tr>
-            <th>注文日</th>
-            <th>配送先</th>
-            <th>注文商品</th>
-            <th>支払金額</th>
-            <th>ステータス</th>
-            <th>注文詳細</th>
+            <th class="bg-light">注文日</th>
+            <th class="bg-light">配送先</th>
+            <th class="bg-light">注文商品</th>
+            <th class="bg-light">支払金額</th>
+            <th class="bg-light">ステータス</th>
+            <th class="bg-light">注文詳細</th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/public/orders/show.html.erb
+++ b/app/views/public/orders/show.html.erb
@@ -6,13 +6,13 @@
     <div class="col-md-6">
       <table class="table table-bordered">
         <b>注文情報</b><br>
-        <tbody class="thead-light">
+        <tbody>
           <tr>
-            <th class="font-weight-normal">注文日</th>
+            <th class="font-weight-normal bg-light">注文日</th>
             <td><%= @order.created_at.strftime("%Y/%m/%d") %></td>
           </tr>
           <tr>
-            <th class="font-weight-normal">配送先</th>
+            <th class="font-weight-normal bg-light">配送先</th>
             <td>
                 〒<%= @order.postcode%><br>
                 <%= @order.address%><br>
@@ -20,11 +20,11 @@
             </td>
           </tr>
           <tr>
-            <th class="font-weight-normal">支払い方法</th>
+            <th class="font-weight-normal bg-light">支払い方法</th>
             <td><%= Order.payment_methods_i18n[@order.payment_method] %></td>
           </tr>
           <tr>
-            <th class="font-weight-normal">ステータス</th>
+            <th class="font-weight-normal bg-light">ステータス</th>
             <td><%= Order.statuses_i18n[@order.status] %></td>
           </tr>
         </tbody>
@@ -34,17 +34,17 @@
     <div class="col-md-4">
       <table class="table table-bordered">
         <b>請求情報</b><br>
-        <tbody class="thead-light">
+        <tbody>
             <tr>
-              <th class="font-weight-normal">商品合計</th>
+              <th class="font-weight-normal bg-light">商品合計</th>
               <td><%= number_with_delimiter(@order.payment - @order.shipping_fee) %> 円</td>
             </tr>
             <tr>
-              <th class="font-weight-normal">配送料</th>
+              <th class="font-weight-normal bg-light">配送料</th>
               <td><%= number_with_delimiter(@order.shipping_fee) %> 円</td>
             </tr>
             <tr>
-              <th><b>ご請求額</b></th>
+              <th class="bg-light"><b>ご請求額</b></th>
               <td><%= number_with_delimiter(@order.payment) %> 円</td>
             </tr>
         </tbody>
@@ -53,12 +53,12 @@
   </div>
   <table class="table table-bordered">
     <b>注文内容</b>
-    <thead class="thead-light">
-      <th class="font-weight-normal">商品</th>
-      <th class="font-weight-normal">単価（税込）</th>
-      <th class="font-weight-normal">個数</th>
-      <th class="font-weight-normal">小計</th>
-      <th class="font-weight-normal">ステータス</th>
+    <thead>
+      <th class="font-weight-normal bg-light">商品</th>
+      <th class="font-weight-normal bg-light">単価（税込）</th>
+      <th class="font-weight-normal bg-light">個数</th>
+      <th class="font-weight-normal bg-light">小計</th>
+      <th class="font-weight-normal bg-light">ステータス</th>
     </thead>
     <tbody>
       <!--注文商品個別表示-->


### PR DESCRIPTION
#[admin]注文詳細画面, [publc]注文完了画面レイアウト変更等
-[admin]注文詳細画面レイアウト変更
-[public]注文完了画面レイアウト変更
-各種注文一覧テーブルのヘッダーの色を変更
-注文入力画面で"ご自宅"選択時の配達先宛名のエラー修正
-[admin]注文詳細画面でのステータス更新メッセージエラー修正、メッセージ複数表示に変更
-上記に伴いview/layouts/flash_messageを一部変更しました